### PR TITLE
Small tweak to stocks cog logic

### DIFF
--- a/cogs/stocks.py
+++ b/cogs/stocks.py
@@ -119,22 +119,27 @@ class Stocks(commands.Cog):
                 price_delta = float(change_dir) * random.uniform(delta_lower_limit, delta_upper_limit)
                 new_price = currentPrices.get(itemType).get(item) + price_delta
 
-                #stock splitting if price is above 1000
+                # Stock splitting if price is above 1000
                 # TODO: some marker in data that a split occured?
-                if newPrice >= 1000.00:
+                if new_price >= 1000.00:
                     split_type = float(random.randint(2,5))
-                    newPrice /= split_type
+                    new_price /= split_type
                     for server in server_list:
                         self.set_server_owned_stocks(server, item, split_type)
 
-                #updating the current price
-                currentPrices.get(itemType)[item] = new_price if new_price >= 0.00 else 0.00
+                # Updating the current price
+                currentPrices.get(itemType)[item] = new_price if new_price > 0.00 else 0.00
 
-                #calculating differences & resetting the recorded sale count
+                # Delete all owned stocks on a server if the new price is now 0
+                if new_price == 0:
+                    for server in server_list:
+                        self.set_server_owned_stocks(server, item, 0)
+
+                # Calculating differences & resetting the recorded sale count
                 deltaPrices.get(itemType)[item] = currentPrices.get(itemType).get(item) - oldPrices.get(itemType).get(item)
                 saleData.get(itemType)[item] = 0
 
-                #saves the last time stock data was edited
+                # Saves the last time stock data was edited
                 self.settings["lastCheck"] = str(datetime.now())
                 write_file(self.settings, self.userData)
 

--- a/cogs/stocks.py
+++ b/cogs/stocks.py
@@ -335,12 +335,12 @@ class Stocks(commands.Cog):
     async def bankrupt(self, ctx):
         self.db_check(ctx)
 
+        portfolio = self.userData.get('playerData').get(str(ctx.guild.id)).get(str(ctx.author.id))
         player_money = portfolio.get('money')
         if player_money > 0.0:
-            await ctx.send(f"{ctx.message.author.mention}: you still have {player_money} left.")
+            await ctx.send(f"{ctx.message.author.mention}: you still have ${player_money} left.")
             return
 
-        portfolio = self.userData.get('playerData').get(str(ctx.guild.id)).get(str(ctx.author.id))
         if portfolio.get('investedCommodities') or portfolio.get("investedStocks"):
             await ctx.send(f"{ctx.message.author.mention}: you still have some assets in your portfolio.")
             return
@@ -416,11 +416,11 @@ class Stocks(commands.Cog):
 
         #embed for commodities
         c_embed = discord.Embed(title="Commodities (Price per unit)", description=c_listings, color=0xff0000)
-        c_embed.set_image(url="https://media.tenor.com/AbkJkB1pGr8AAAAi/hutao-money-rain.gif")
+        c_embed.set_image(url="https://media.tenor.com/images/d8ac4e749942f31ddfb928dee86244d3/tenor.gif")
 
         #embed for stocks
         s_embed = discord.Embed(title="Stocks (Price per share)", description=s_listings, color=0x0000ff)
-        s_embed.set_image(url="https://media.tenor.com/images/d8ac4e749942f31ddfb928dee86244d3/tenor.gif")
+        s_embed.set_image(url="https://c.tenor.com/R5xdZRysv0QAAAAC/tenor.gif")
 
         embeds = [c_embed, s_embed]
         view = PaginatedView(embeds)

--- a/cogs/stocks.py
+++ b/cogs/stocks.py
@@ -329,6 +329,22 @@ class Stocks(commands.Cog):
         write_file(self.settings, self.userData)
 
     ########
+    # brankrupt: For when the player has no assets
+    ########
+    @commands.command(name="bankrupt", description="Print some money if you have no assets :)", aliases=['b', 'B'])
+    async def bankrupt(self, ctx):
+        self.db_check(ctx)
+
+        portfolio = self.userData.get('playerData').get(str(ctx.guild.id)).get(str(ctx.author.id))
+        if portfolio.get('investedCommodities') or portfolio.get("investedStocks"):
+            await ctx.send(f"{ctx.message.author.mention}: you still have some assets in your portfolio.")
+            return
+
+        portfolio['money'] += 1000.00
+        await ctx.send(f"{ctx.message.author.mention}: $1000.00 has been deposited into your account.")
+        write_file(self.settings, self.userData)
+
+    ########
     # portfolio: Grab the portfolio of the requester
     ########
     @commands.command(name="portfolio", description="Request your investment portfolio", aliases=['p', 'P'])

--- a/cogs/stocks.py
+++ b/cogs/stocks.py
@@ -106,24 +106,18 @@ class Stocks(commands.Cog):
                     #new difference
                     deltaPrices.get(itemType)[item] = 0
 
-                #new price
+                # Determining the new price + setup for determining the direction of the change
+                delta_lower_limit, delta_upper_limit = 0.0, 32.0
                 roll = random.randint(0, 100)
-                weightMod = 0
-                deltaLowerLimit, deltaUpperLimit = 0.0, 32.0
+                threshold = random.randint(0, 100)
                 if item in volatiles:
-                    weightMod = -30 if (saleData.get(itemType).get(item) / 1000 < 10) else -10
-                    deltaLowerLimit, deltaUpperLimit = 25.0, 1500.0 if (roll > 50 + weightMod) else 3000.0
-                else:
-                    demandBonus = saleData.get(itemType).get(item) / 1000
-                    negativeBonus = 0 if (currentPrices.get(itemType).get(item) >= 0) else 10
-                    totalBonus = demandBonus + negativeBonus
-                    weightMod = 40 if (50 + totalBonus > 90) else -40 if (50 - totalBonus < 10) else totalBonus
+                    delta_lower_limit, delta_upper_limit = 50.0, 200.0 if (roll > 50 + weightMod) else 100.0
 
-                #determining whether the price increases or decreases
-                changeDir = 1 if (roll <= (50 + weightMod)) else -1
+                # Determining the direction of the change
+                change_dir = 1 if (roll <= threshold) else -1
                 oldPrices.get(itemType)[item] = currentPrices.get(itemType).get(item)
-                priceDelta = float(changeDir) * random.uniform(deltaLowerLimit, deltaUpperLimit)
-                newPrice = currentPrices.get(itemType).get(item) + priceDelta
+                price_delta = float(change_dir) * random.uniform(delta_lower_limit, delta_upper_limit)
+                new_price = currentPrices.get(itemType).get(item) + price_delta
 
                 #stock splitting if price is above 1000
                 # TODO: some marker in data that a split occured?
@@ -134,7 +128,7 @@ class Stocks(commands.Cog):
                         self.set_server_owned_stocks(server, item, split_type)
 
                 #updating the current price
-                currentPrices.get(itemType)[item] = newPrice if newPrice >= -500.00 else -500.00
+                currentPrices.get(itemType)[item] = new_price if new_price >= 0.00 else 0.00
 
                 #calculating differences & resetting the recorded sale count
                 deltaPrices.get(itemType)[item] = currentPrices.get(itemType).get(item) - oldPrices.get(itemType).get(item)

--- a/cogs/stocks.py
+++ b/cogs/stocks.py
@@ -111,7 +111,7 @@ class Stocks(commands.Cog):
                 roll = random.randint(0, 100)
                 threshold = random.randint(0, 100)
                 if item in volatiles:
-                    delta_lower_limit, delta_upper_limit = 50.0, 200.0 if (roll > 50 + weightMod) else 100.0
+                    delta_lower_limit, delta_upper_limit = 50.0, 200.0 if (roll > threshold) else 100.0
 
                 # Determining the direction of the change
                 change_dir = 1 if (roll <= threshold) else -1
@@ -334,6 +334,11 @@ class Stocks(commands.Cog):
     @commands.command(name="bankrupt", description="Print some money if you have no assets :)", aliases=['b', 'B'])
     async def bankrupt(self, ctx):
         self.db_check(ctx)
+
+        player_money = portfolio.get('money')
+        if player_money > 0.0:
+            await ctx.send(f"{ctx.message.author.mention}: you still have {player_money} left.")
+            return
 
         portfolio = self.userData.get('playerData').get(str(ctx.guild.id)).get(str(ctx.author.id))
         if portfolio.get('investedCommodities') or portfolio.get("investedStocks"):


### PR DESCRIPTION
Stock prices follow a 1D random walk in a random environment now and---for the time being (maybe)---is no longer influenced by purchase history.  Also made the game a little more unforgiving as players can now lose everything and must start from $1000 again in that scenario.

This should be the last set of changes to this cog for the time being.  I think a bulk of the logic should be moved over to an API that the bot can hook into.  So any future changes that end up being made will be done there.